### PR TITLE
[fix] Swagger UI 경로 설정 수정 - OpenAPI 3.0 표준 준수

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -50,7 +50,7 @@ logging:
 # Swagger 설정
 springdoc:
   api-docs:
-    path: /api-docs
+    path: /v3/api-docs
   swagger-ui:
     path: /swagger-ui.html
     operationsSorter: method

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,7 +62,7 @@ logging:
 # Swagger 설정
 springdoc:
   api-docs:
-    path: /api-docs
+    path: /v3/api-docs
   swagger-ui:
     path: /swagger-ui.html
     operationsSorter: method


### PR DESCRIPTION
## 📝 작업 내용
- **Swagger UI 경로 설정 수정**
  - SpringDoc OpenAPI 2.6.0 표준에 맞춰 API docs 경로를 `/api-docs`에서 `/v3/api-docs`로 변경
  - OpenAPI 3.0 표준 준수로 Swagger UI 정상 작동 보장
  - 개발/프로덕션 환경 설정 파일 모두 수정

## 🧪 테스트 방법
- **Swagger UI 접근 테스트**: `https://api.repit.life/swagger-ui.html`
- **OpenAPI JSON 문서**: `https://api.repit.life/v3/api-docs`
- **Health Check**: `https://api.repit.life/health`
- **배포 후 로그 확인**: SpringDoc 관련 에러 메시지 해결 확인

## 🔗 관련 이슈
- Swagger UI 404 에러 및 `No static resource api/api-docs/swagger-config` 에러 해결

---

## ✅ 체크리스트
- [x] 제목 형식 준수 (`[fix] Swagger UI 경로 설정 수정`)
- [ ] 라벨 지정 완료 (bugfix)
- [ ] Reviewer 지정 완료