### PR TITLE
[fix] SpringDoc OpenAPI context-path 호환성 개선 - use-management-port 설정 추가

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -56,6 +56,7 @@ springdoc:
     operationsSorter: method
     tagsSorter: alpha
   packages-to-scan: com.repit.api.controller
+  use-management-port: false
 
 # 서버 포트 설정
 server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,7 @@ springdoc:
     operationsSorter: method
     tagsSorter: alpha
   packages-to-scan: com.repit.api.controller
+  use-management-port: false
 
 # 서버 포트 설정
 server:


### PR DESCRIPTION
## 📝 작업 내용
- **SpringDoc OpenAPI context-path 호환성 개선**
  - `use-management-port: false` 설정 추가로 SpringDoc이 별도 관리 포트 사용하지 않도록 수정
  - context-path `/api`와 SpringDoc OpenAPI 2.6.0 간의 경로 충돌 문제 해결
  - `api/v3/api-docs/swagger-config` 및 `api/swagger-ui/index.html` 접근 오류 수정
  - 개발/프로덕션 환경 설정 파일 모두 적용

## 🧪 테스트 방법
- **Swagger UI 접근 테스트**: `https://api.repit.life/api/swagger-ui.html`
- **OpenAPI JSON 문서**: `https://api.repit.life/api/v3/api-docs`
- **Health Check**: `https://api.repit.life/api/health`
- **배포 후 로그 확인**: SpringDoc 관련 에러 메시지 해결 확인
- **프론트엔드 API 호출**: `/api` 경로 포함하여 API 엔드포인트 접근 테스트

## 🔗 관련 이슈
- Swagger UI 404 에러 및 `No static resource api/v3/api-docs/swagger-config` 에러 해결
- SpringDoc OpenAPI 2.6.0과 context-path `/api` 호환성 문제 해결

---

## ✅ 체크리스트
- [x] 제목 형식 준수 (`[fix] SpringDoc OpenAPI context-path 호환성 개선`)
- [ ] 라벨 지정 완료 (bugfix)
- [ ] Reviewer 지정 완료