### PR TITLE
[feat] CORS 설정 추가 - localhost:3000 허용

### DIFF
--- a/src/main/java/com/repit/api/config/WebConfig.java
+++ b/src/main/java/com/repit/api/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.repit.api.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -13,6 +14,16 @@ public class WebConfig implements WebMvcConfigurer {
     @Autowired
     public WebConfig(AuthInterceptor authInterceptor) {
         this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:3000", "http://127.0.0.1:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 
     @Override


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- CORS 설정 추가로 localhost:3000에서 API 접근 허용
- WebConfig에 addCorsMappings 메서드 구현
- 프론트엔드와 백엔드 간 통신 가능하도록 설정

## 테스트 방법
- 프론트엔드(localhost:3000)에서 API 호출 테스트
- 브라우저 개발자 도구에서 CORS 에러 확인
- Postman으로 OPTIONS 요청 테스트

## 관련 이슈
- 프론트엔드 CORS 정책 에러 해결

---

## 머지 전 필수 체크리스트
- [x] 제목 형식 지켰음 (`[feat] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, frontend)
- [ ] Reviewer 지정 완료